### PR TITLE
config: Modified configuration for deployment

### DIFF
--- a/consumer-v3/build.gradle.kts
+++ b/consumer-v3/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.micrometer:micrometer-registry-cloudwatch2")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.testng:testng:6.9.6")
 }
 
 tasks.withType<Test> {

--- a/consumer-v3/src/main/java/edu/northeastern/cs6650/consumer/config/JacksonConfig.java
+++ b/consumer-v3/src/main/java/edu/northeastern/cs6650/consumer/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package edu.northeastern.cs6650.consumer.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+}

--- a/deployment/start-consumer.sh
+++ b/deployment/start-consumer.sh
@@ -1,23 +1,26 @@
 #!/bin/bash
 # ==================================================
 # Usage: run this script on the consumer EC2 instance
-# Postgres : 172.31.27.218:5432
-# RabbitMQ : 172.31.26.68:5672
-# Consumer : 172.31.17.225:8081
+# Postgres : 172.31.8.77:5432
+# Redis : 172.31.5.215
+# RabbitMQ : 172.31.2.202:5672
+# Consumer : 172.31.12.100:8081
 # ==================================================
 
-DB_URL="${DB_URL:-jdbc:postgresql://172.31.27.218:5432/chatflow}"
+DB_URL="${DB_URL:-jdbc:postgresql://172.31.8.77:5432/chatflow}"
 DB_USER="${DB_USER:-admin}"
 DB_PASSWORD="${DB_PASSWORD:-admin}"
 
 nohup java -jar ~/consumer-v3-0.0.1-SNAPSHOT.jar \
-  --spring.rabbitmq.host=172.31.26.68 \
+  --spring.rabbitmq.host=172.31.2.202 \
   --spring.rabbitmq.port=5672 \
   --spring.rabbitmq.username=admin \
   --spring.rabbitmq.password=admin \
   --spring.datasource.url="${DB_URL}" \
   --spring.datasource.username="${DB_USER}" \
   --spring.datasource.password="${DB_PASSWORD}" \
+  --spring.data.redis.host=172.31.5.215 \
+  --spring.data.redis.port=6379 \
   --db.writer.batch-size=${DB_BATCH_SIZE:-500} \
   --db.writer.flush-interval-ms=${DB_FLUSH_INTERVAL_MS:-100} \
   --consumer.thread-count=20 \

--- a/deployment/start-server1.sh
+++ b/deployment/start-server1.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
 # ==================================================
 # Usage: run this script on the respective EC2 instance
-# RabbitMQ : 172.31.26.68
-# Consumer : 172.31.17.225
-# Server1  : 172.31.31.34
-# Server2  : 172.31.18.129
-# Server3  : 172.31.17.217
-# Server4  : 172.31.23.85
+# RabbitMQ : 172.31.2.202
+# Redis : 172.31.5.215
+# Consumer : 172.31.12.100
+# Server1  : 172.31.39.145
+# Server2  : 172.31.39.148
+# Server3  : 172.31.9.40
+# Server4  : 172.31.9.32
 # ==================================================
 
 
 # ==================================================
-# Server1 — run on 172.31.31.34
+# Server1 — run on 172.31.39.145
 # ==================================================
 nohup java -jar ~/server-v2-0.0.1-SNAPSHOT.jar \
-  --spring.rabbitmq.host=172.31.26.68 \
+  --spring.rabbitmq.host=172.31.2.202 \
   --spring.rabbitmq.port=5672 \
   --spring.rabbitmq.username=admin \
   --spring.rabbitmq.password=admin \
-  --server.url=http://172.31.31.34:8080 \
-  --consumer.url=http://172.31.17.225:8081 \
+  --spring.data.redis.host=172.31.5.215 \
+  --spring.data.redis.port=6379 \
+  --server.url=http://172.31.39.145:8080 \
+  --consumer.url=http://172.31.12.100:8081 \
   --rabbitmq.pool.connections=2 \
   --rabbitmq.pool.channels-per-connection=25 \
   > server.log 2>&1 &

--- a/deployment/start-server2.sh
+++ b/deployment/start-server2.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
 # ==================================================
 # Usage: run this script on the respective EC2 instance
-# RabbitMQ : 172.31.26.68
-# Consumer : 172.31.17.225
-# Server1  : 172.31.31.34
-# Server2  : 172.31.18.129
-# Server3  : 172.31.17.217
-# Server4  : 172.31.23.85
+# RabbitMQ : 172.31.2.202
+# Redis : 172.31.5.215
+# Consumer : 172.31.12.100
+# Server1  : 172.31.39.145
+# Server2  : 172.31.39.148
+# Server3  : 172.31.9.40
+# Server4  : 172.31.9.32
 # ==================================================
 
 
 # ==================================================
-# Server2 — run on 172.31.18.129
+# Server2 — run on 172.31.39.148
 # ==================================================
 nohup java -jar ~/server-v2-0.0.1-SNAPSHOT.jar \
-  --spring.rabbitmq.host=172.31.26.68 \
+  --spring.rabbitmq.host=172.31.2.202 \
   --spring.rabbitmq.port=5672 \
   --spring.rabbitmq.username=admin \
   --spring.rabbitmq.password=admin \
-  --server.url=http://172.31.18.129:8080 \
-  --consumer.url=http://172.31.17.225:8081 \
+  --spring.data.redis.host=172.31.5.215 \
+  --spring.data.redis.port=6379 \
+  --server.url=http://172.31.39.148:8080 \
+  --consumer.url=http://172.31.12.100:8081 \
   --rabbitmq.pool.connections=2 \
   --rabbitmq.pool.channels-per-connection=25 \
   > server.log 2>&1 &

--- a/deployment/start-server3.sh
+++ b/deployment/start-server3.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
 # ==================================================
 # Usage: run this script on the respective EC2 instance
-# RabbitMQ : 172.31.26.68
-# Consumer : 172.31.17.225
-# Server1  : 172.31.31.34
-# Server2  : 172.31.18.129
-# Server3  : 172.31.17.217
-# Server4  : 172.31.23.85
+# RabbitMQ : 172.31.2.202
+# Redis : 172.31.5.215
+# Consumer : 172.31.12.100
+# Server1  : 172.31.39.145
+# Server2  : 172.31.39.148
+# Server3  : 172.31.9.40
+# Server4  : 172.31.9.32
 # ==================================================
 
 
 # ==================================================
-# Server3 — run on 172.31.17.217
+# Server3 — run on 172.31.9.40
 # ==================================================
 nohup java -jar ~/server-v2-0.0.1-SNAPSHOT.jar \
-  --spring.rabbitmq.host=172.31.26.68 \
+  --spring.rabbitmq.host=172.31.2.202 \
   --spring.rabbitmq.port=5672 \
   --spring.rabbitmq.username=admin \
   --spring.rabbitmq.password=admin \
-  --server.url=http://172.31.17.217:8080 \
-  --consumer.url=http://172.31.17.225:8081 \
+  --spring.data.redis.host=172.31.5.215 \
+  --spring.data.redis.port=6379 \
+  --server.url=http://172.31.9.40:8080 \
+  --consumer.url=http://172.31.12.100:8081 \
   --rabbitmq.pool.connections=2 \
   --rabbitmq.pool.channels-per-connection=25 \
   > server.log 2>&1 &

--- a/deployment/start-server4.sh
+++ b/deployment/start-server4.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
 # ==================================================
 # Usage: run this script on the respective EC2 instance
-# RabbitMQ : 172.31.26.68
-# Consumer : 172.31.17.225
-# Server1  : 172.31.31.34
-# Server2  : 172.31.18.129
-# Server3  : 172.31.17.217
-# Server4  : 172.31.23.85
+# RabbitMQ : 172.31.2.202
+# Redis : 172.31.5.215
+# Consumer : 172.31.12.100
+# Server1  : 172.31.39.145
+# Server2  : 172.31.39.148
+# Server3  : 172.31.9.40
+# Server4  : 172.31.9.32
 # ==================================================
 
 
 # ==================================================
-# Server4 — run on 172.31.23.85
+# Server4 — run on 172.31.9.32
 # ==================================================
 nohup java -jar ~/server-v2-0.0.1-SNAPSHOT.jar \
-  --spring.rabbitmq.host=172.31.26.68 \
+  --spring.rabbitmq.host=172.31.2.202 \
   --spring.rabbitmq.port=5672 \
   --spring.rabbitmq.username=admin \
   --spring.rabbitmq.password=admin \
-  --server.url=http://172.31.23.85:8080 \
-  --consumer.url=http://172.31.17.225:8081 \
+  --spring.data.redis.host=172.31.5.215 \
+  --spring.data.redis.port=6379 \
+  --server.url=http://172.31.9.32:8080 \
+  --consumer.url=http://172.31.12.100:8081 \
   --rabbitmq.pool.connections=2 \
   --rabbitmq.pool.channels-per-connection=25 \
   > server.log 2>&1 &


### PR DESCRIPTION
Summary
                                                                                                           
  - Updated all deployment scripts (start-server1~4.sh, start-consumer.sh) with new EC2 private IP       
  addresses for all services (RabbitMQ, Redis, Consumer, Server1–4)                                        
  - Added Redis connection arguments (--spring.data.redis.host / --spring.data.redis.port) to all server
  and consumer startup scripts to wire up the Redis cache layer                                            
  - Added JacksonConfig.java to the consumer module to register JavaTimeModule on the ObjectMapper bean, 
  fixing Java 8 date/time serialization issues                                                             
  - Added testng dependency to consumer-v3/build.gradle.kts                                              
                                                                                                           
  Test plan                                                                                              
                                                                                                           
  - SSH into each EC2 instance and run the corresponding startup script; confirm the service starts without
   errors
  - Verify server instances can connect to RabbitMQ at 172.31.2.202:5672                                   
  - Verify server and consumer instances can connect to Redis at 172.31.5.215:6379                         
  - Verify consumer can connect to Postgres at 172.31.8.77:5432                                            
  - Send a chat message end-to-end and confirm it is persisted and cached correctly 

Close #5